### PR TITLE
feat: add search params to get all students

### DIFF
--- a/src/modules/student/__test__/student.e2e.spec.ts
+++ b/src/modules/student/__test__/student.e2e.spec.ts
@@ -154,6 +154,71 @@ describe('Student Module', () => {
         });
     });
 
+    it('should filter students with search query', async () => {
+      const testUserPayload = {
+        id: testUserId,
+        email: 'admin@example.com',
+      };
+      const studentsResponse: StudentResponseDto[] = [
+        {
+          id: 'uuid',
+          fullName: 'John Doe',
+          email: 'Q5NtD@example.com',
+          career: {
+            id: 'id',
+            name: 'Computer Science',
+          },
+          collegeId: 1,
+          subjects: [
+            {
+              id: 'id',
+              name: 'Mathematics',
+              career: {
+                id: 'id',
+                name: 'Computer Science',
+              },
+            },
+          ],
+          qualifications: [80, 90],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        },
+      ];
+
+      const authToken = jwtService.sign(testUserPayload);
+
+      jest
+        .spyOn(mockStudentService, 'getAll')
+        .mockResolvedValue(studentsResponse);
+
+      await request(app.getHttpServer())
+        .get('/student?search=Q5NtD@example.com')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          const expectedResponse = expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.any(String),
+              fullName: expect.any(String),
+              email: expect.any(String),
+              career: expect.objectContaining({
+                id: expect.any(String),
+                name: expect.any(String),
+              }),
+              collegeId: expect.any(Number),
+              subjects: expect.any(Array),
+              qualifications: expect.any(Array),
+              createdAt: expect.any(String),
+              updatedAt: expect.any(String),
+              deletedAt: null,
+            }),
+          ]);
+
+          expect(body).toEqual(expectedResponse);
+        });
+    });
+
     it('should throw an exception if user is not authenticated', async () => {
       await request(app.getHttpServer())
         .get('/student')

--- a/src/modules/student/application/service/student.service.ts
+++ b/src/modules/student/application/service/student.service.ts
@@ -30,8 +30,8 @@ export class StudentService implements IStudentService {
     private readonly authService: IAuthService,
   ) {}
 
-  async getAll(): Promise<StudentResponseDto[]> {
-    const dbStudents = await this.studentRepository.getAll();
+  async getAll(search?: string): Promise<StudentResponseDto[]> {
+    const dbStudents = await this.studentRepository.getAll(search);
 
     return dbStudents.map((student) =>
       this.studentMapper.fromStudentToStudentResponseDto(student),

--- a/src/modules/student/controller/student.controller.ts
+++ b/src/modules/student/controller/student.controller.ts
@@ -6,6 +6,7 @@ import {
   Inject,
   Param,
   Post,
+  Query,
 } from '@nestjs/common';
 import {
   IStudentService,
@@ -28,8 +29,10 @@ export class StudentController {
 
   @Auth(USER_ROLES.ADMIN)
   @Get()
-  async getAll(): Promise<StudentResponseDto[]> {
-    return await this.studentService.getAll();
+  async getAll(
+    @Query('search') search?: string,
+  ): Promise<StudentResponseDto[]> {
+    return await this.studentService.getAll(search);
   }
 
   @Auth()

--- a/src/modules/student/domain/interfaces/student-repository.interface.ts
+++ b/src/modules/student/domain/interfaces/student-repository.interface.ts
@@ -3,7 +3,7 @@ import { Student } from '../student.domain';
 export const STUDENT_REPOSITORY_KEY = 'STUDENT_REPOSITORY';
 
 export interface IStudentRepository {
-  getAll(): Promise<Student[]>;
+  getAll(search?: string): Promise<Student[]>;
   findOneById(id: string): Promise<Student>;
   findOneByEmail(email: string): Promise<Student>;
   create(student: Student): Promise<Student>;

--- a/src/modules/student/domain/interfaces/student-service.interface.ts
+++ b/src/modules/student/domain/interfaces/student-service.interface.ts
@@ -5,7 +5,7 @@ import { StudentResponseDto } from '../../application/dto/student-response.dto';
 export const STUDENT_SERVICE_KEY = 'STUDENT_SERVICE';
 
 export interface IStudentService {
-  getAll(): Promise<StudentResponseDto[]>;
+  getAll(search?: string): Promise<StudentResponseDto[]>;
   getOneById(id: string): Promise<StudentResponseDto>;
   create(
     createStudentDto: CreateStudentDto,

--- a/src/modules/student/infrastructure/database/student.postgresql.repository.ts
+++ b/src/modules/student/infrastructure/database/student.postgresql.repository.ts
@@ -1,7 +1,7 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { IStudentRepository } from '../../domain/interfaces/student-repository.interface';
 import { StudentEntity } from './student.entity';
-import { Repository } from 'typeorm';
+import { Repository, ILike } from 'typeorm';
 import { Student } from '../../domain/student.domain';
 import { StudentAlreadyExistsException } from '../../domain/exceptions/student-already-exists.exception';
 import { StudentNotFoundException } from '../../domain/exceptions/student-not-found.exception';
@@ -12,8 +12,18 @@ export class StudentRepository implements IStudentRepository {
     private readonly repository: Repository<Student>,
   ) {}
 
-  async getAll(): Promise<Student[]> {
-    return await this.repository.find();
+  async getAll(search?: string): Promise<Student[]> {
+    if (search) {
+      return await this.repository.find({
+        where: [
+          { fullName: ILike(`%${search}%`) },
+          { email: ILike(`%${search}%`) },
+        ],
+        relations: ['career', 'user'],
+      });
+    }
+
+    return await this.repository.find({ relations: ['career', 'user'] });
   }
 
   async findOneById(id: string): Promise<Student> {


### PR DESCRIPTION
# Summary
- Add search params to the get all students endpoint, to be able to filter them by name or email